### PR TITLE
Bump default to 5.0.20 and fix the action since mongo was replaced by mongosh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,5 @@ jobs:
           $connstr = $Env:MongoDBConnectionString
           Write-Host "Connection String: $connstr"
 
-          $result = mongo "$connstr"
+          $result = mongosh "$connstr"
           echo $result

--- a/action.yml
+++ b/action.yml
@@ -41,9 +41,7 @@ runs:
         
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
-        $installServiceCommand = @'
-        & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName
-        '@
+        $installServiceCommand = @'& "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName'@
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
           $installServiceCommand = $installServiceCommand + ' --replSet $replicaSet'
@@ -53,9 +51,7 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          $exec = @'
-          & "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'
-          '@
+          $exec = @'& "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()''@
           Invoke-Expression $exec
         }
 

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,8 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          & "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'
+          $initiateReplicaSetCommand = "$databaseBinDirectory\mongod "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'"
+          Invoke-Expression $initiateReplicaSetCommand
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          & "$databaseBinDirectory\mongo.exe" --host "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()""
+          & "$databaseBinDirectory\mongo.exe" --host "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()"
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -49,9 +49,11 @@ runs:
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
 
         if($replicaSet) {
+          echo "Starting MongoD with replica"
           & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName --replSet $replicaSet
         }
         else {
+          echo "Starting MongoD without replica"
           & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName
         }
 

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
         echo "::endgroup::"
 
         if($replicaSet) {
-          & "$databaseBinDirectory\mongo.exe" --host "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()"
+          & "$databaseBinDirectory\mongo.exe" --host ""mongodb://127.0.0.1:${{ inputs.mongodb-port }}"" --eval ""rs.initiate()""
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -41,13 +41,14 @@ runs:
         
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
-        $installServiceCommand = "$databaseBinDirectory\mongod --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
-          $installServiceCommand = $installServiceCommand + ' --replSet $replicaSet'
+          & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName --replSet $replicaSet"
+        }
+        else {
+          & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
         }
 
-        Invoke-Expression $installServiceCommand
         net start $databaseServiceName
 
         if($replicaSet) {

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
         echo "::endgroup::"
 
         if($replicaSet) {
-          & mongosh --host "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()"
+          & mongosh "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()"
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,9 @@ inputs:
     default: ""
     
   mongodb-version:
-    description: "MongoDB version (default 5.0.11)"
+    description: "MongoDB version (default 5.0.20)"
     required: false
-    default: "5.0.11"  
+    default: "5.0.20"  
 
   mongodb-port:
     description: "MongoDB port to use (default 27017)"

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          $initiateReplicaSetCommand = "$databaseBinDirectory\mongod "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'"
+          $initiateReplicaSetCommand = "$databaseBinDirectory\mongo "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'"
           Invoke-Expression $initiateReplicaSetCommand
         }
 

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
         echo "::endgroup::"
 
         if($replicaSet) {
-          & mongosh --host ""mongodb://127.0.0.1:${{ inputs.mongodb-port }}"" --eval ""rs.initiate()""
+          & mongosh --host "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()"
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          Invoke-Expression "$databaseBinDirectory\mongo ""mongodb://127.0.0.1:${{ inputs.mongodb-port }}"" --eval 'rs.initiate()'"
+          Invoke-Expression "$databaseBinDirectory\mongosh ""mongodb://127.0.0.1:${{ inputs.mongodb-port }}"" --eval 'rs.initiate()'"
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,9 @@ runs:
         
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
-        $installServiceCommand = "$databaseBinDirectory\mongod.exe --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
+        $installServiceCommand = @'
+        & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
+        '@
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
           $installServiceCommand = $installServiceCommand + ' --replSet $replicaSet'
@@ -51,7 +53,10 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          Invoke-Expression "$databaseBinDirectory\mongo.exe ""mongodb://127.0.0.1:${{ inputs.mongodb-port }}"" --eval 'rs.initiate()'"
+          $exec = @'
+          & "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'"
+          '@
+          Invoke-Expression $exec
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -41,22 +41,18 @@ runs:
         
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
-        $installServiceCommand = @'
-& "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName
+        $installServiceCommand = """$databaseBinDirectory\mongod.exe"" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
 '@
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
           $installServiceCommand = $installServiceCommand + ' --replSet $replicaSet'
         }
 
-        Invoke-Expression $installServiceCommand
+        & $installServiceCommand
         net start $databaseServiceName
 
         if($replicaSet) {
-          $exec = @'
-& "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'
-'@
-          Invoke-Expression $exec
+          & "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -41,13 +41,13 @@ runs:
         
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
-        $installServiceCommand = """$databaseBinDirectory\mongod.exe"" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
+        $installServiceCommand = "$databaseBinDirectory\mongod --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
           $installServiceCommand = $installServiceCommand + ' --replSet $replicaSet'
         }
 
-        & $installServiceCommand
+        Invoke-Expression $installServiceCommand
         net start $databaseServiceName
 
         if($replicaSet) {

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         mkdir $databaseLogsDirectory > $null
         
         $version = [Version]::new("${{ inputs.mongodb-version }}")
-        $databaseBinDirectory = "C:\'Program Files'\MongoDB\Server\$($version.Major).$($version.Minor)\bin"
+        $databaseBinDirectory = "C:\Program Files\MongoDB\Server\$($version.Major).$($version.Minor)\bin"
         
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,6 @@ runs:
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
         $installServiceCommand = """$databaseBinDirectory\mongod.exe"" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
-'@
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
           $installServiceCommand = $installServiceCommand + ' --replSet $replicaSet'

--- a/action.yml
+++ b/action.yml
@@ -38,10 +38,16 @@ runs:
         
         $version = [Version]::new("${{ inputs.mongodb-version }}")
         $databaseBinDirectory = "C:\Program Files\MongoDB\Server\$($version.Major).$($version.Minor)\bin"
-        
-        choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
+        echo "::group:: Installing MongoDB $version to $databaseBinDirectory"
+
+        choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y --no-progress
+
+        echo "::endgroup::"
+
+        echo "::group:: Starting MongoDB $databaseServiceName on port ${{ inputs.mongodb-port }}"
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
+
         if($replicaSet) {
           & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName --replSet $replicaSet
         }
@@ -50,6 +56,8 @@ runs:
         }
 
         net start $databaseServiceName
+
+        echo "::endgroup::"
 
         if($replicaSet) {
           & "$databaseBinDirectory\mongo.exe" --host "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()"

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
         
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
-        $installServiceCommand = "$databaseBinDirectory\mongod --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
+        $installServiceCommand = "$databaseBinDirectory\mongod.exe --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
           $installServiceCommand = $installServiceCommand + ' --replSet $replicaSet'
@@ -51,7 +51,7 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          Invoke-Expression "$databaseBinDirectory\mongosh ""mongodb://127.0.0.1:${{ inputs.mongodb-port }}"" --eval 'rs.initiate()'"
+          Invoke-Expression "$databaseBinDirectory\mongo.exe ""mongodb://127.0.0.1:${{ inputs.mongodb-port }}"" --eval 'rs.initiate()'"
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          & "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()"
+          & "$databaseBinDirectory\mongo.exe" --host "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()""
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -43,10 +43,10 @@ runs:
 
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
-          & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName --replSet $replicaSet"
+          & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName --replSet $replicaSet
         }
         else {
-          & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
+          & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName
         }
 
         net start $databaseServiceName

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          $initiateReplicaSetCommand = "$databaseBinDirectory\mongo "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'"
+          $initiateReplicaSetCommand = "$databaseBinDirectory\mongo 'mongodb://127.0.0.1:${{ inputs.mongodb-port }}' --eval 'rs.initiate()'"
           Invoke-Expression $initiateReplicaSetCommand
         }
 

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,9 @@ runs:
         
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
-        $installServiceCommand = @'& "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName'@
+        $installServiceCommand = @'
+& "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName
+'@
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
           $installServiceCommand = $installServiceCommand + ' --replSet $replicaSet'
@@ -51,7 +53,9 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          $exec = @'& "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()''@
+          $exec = @'
+& "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'
+'@
           Invoke-Expression $exec
         }
 

--- a/action.yml
+++ b/action.yml
@@ -61,8 +61,16 @@ runs:
 
         echo "::endgroup::"
 
+        echo "::endgroup::"
+
+        echo "::group::Installing MongoDB Shell"
+
+        choco install mongodb-shell
+
+        echo "::endgroup::"
+
         if($replicaSet) {
-          & "$databaseBinDirectory\mongo.exe" --host ""mongodb://127.0.0.1:${{ inputs.mongodb-port }}"" --eval ""rs.initiate()""
+          & mongosh --host ""mongodb://127.0.0.1:${{ inputs.mongodb-port }}"" --eval ""rs.initiate()""
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -51,8 +51,7 @@ runs:
         net start $databaseServiceName
 
         if($replicaSet) {
-          $initiateReplicaSetCommand = "$databaseBinDirectory\mongo 'mongodb://127.0.0.1:${{ inputs.mongodb-port }}' --eval 'rs.initiate()'"
-          Invoke-Expression $initiateReplicaSetCommand
+          & "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval "rs.initiate()"
         }
 
     - name: Start MongoDB Server (Linux)

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         choco install mongodb --version=""${{ inputs.mongodb-version }}"" -y
 
         $installServiceCommand = @'
-        & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName"
+        & "$databaseBinDirectory\mongod.exe" --dbpath $databaseDataDirectory --logpath ""$databaseLogsDirectory\logs.txt"" --port ${{ inputs.mongodb-port }} --bind_ip 127.0.0.1 --install --serviceName $databaseServiceName --serviceDisplayName $databaseServiceName
         '@
         $replicaSet = "${{ inputs.mongodb-replica-set }}"
         if($replicaSet) {
@@ -54,7 +54,7 @@ runs:
 
         if($replicaSet) {
           $exec = @'
-          & "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'"
+          & "$databaseBinDirectory\mongo.exe" "mongodb://127.0.0.1:${{ inputs.mongodb-port }}" --eval 'rs.initiate()'
           '@
           Invoke-Expression $exec
         }


### PR DESCRIPTION
Apparently, 5.0.11 fails on latest Windows Agent Images on Github Action.

```bash
Progress: 100% - Completed download of C:\Users\runneradmin\AppData\Local\Temp\chocolatey\mongodb.install\5.0.11\mongodb-windows-x86_64-5.0.11-signed.msi (290.95 MB).
Download of mongodb-windows-x86_64-5.0.11-signed.msi (290.95 MB) completed.
Hashes match.
Installing mongodb.install...
WARNING: Generic MSI Error. This is a local environment error, not an issue with a package or the MSI itself - it could mean a pending reboot is necessary prior to install or something else (like the same version is already installed). Please see MSI log if available. If not, try again adding '--install-arguments="'/l*v c:\mongodb.install_msi_install.log'"'. Then search the MSI Log for "Return Value 3" and look above that for the error.
ERROR: Running ["C:\Windows\System32\msiexec.exe" /i "C:\Users\runneradmin\AppData\Local\Temp\chocolatey\mongodb.install\5.0.11\mongodb-windows-x86_64-5.0.11-signed.msi" ADDLOCAL="ServerService,Server,ProductFeature,Client,Router,MiscellaneousTools" /qn /norestart MONGO_DATA_PATH="C:\ProgramData\MongoDB\data\db"  MONGO_LOG_PATH="C:\ProgramData\MongoDB\log"  ] was not successful. Exit code was '1603'. Exit code indicates the following: Generic MSI Error. This is a local environment error, not an issue with a package or the MSI itself - it could mean a pending reboot is necessary prior to install or something else (like the same version is already installed). Please see MSI log if available. If not, try again adding '--install-arguments="'/l*v c:\mongodb.install_msi_install.log'"'. Then search the MSI Log for "Return Value 3" and look above that for the error..
The install of mongodb.install was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\mongodb.install\tools\chocolateyInstall.ps1'.
 See log for details.

Progress: Downloading mongodb 5.0.11... 15%
Progress: Downloading mongodb 5.0.11... 41%
Progress: Downloading mongodb 5.0.11... 68%
Progress: Downloading mongodb 5.0.11... 94%
Progress: Downloading mongodb 5.0.11... 100%

mongodb v5.0.11 [Approved]
mongodb package files install completed. Performing other installation steps.
 The install of mongodb was successful.
  Software installed to 'C:\ProgramData\chocolatey\lib\mongodb'

Chocolatey installed 1/2 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - mongodb.install (exited 1603) - Error while running 'C:\ProgramData\chocolatey\lib\mongodb.install\tools\chocolateyInstall.ps1'.
 See log for details.
Invoke-Expression: D:\a\_temp\b18d02a8-f35a-473c-a45e-73587d656b9b.ps1:21
Line |
  21 |  Invoke-Expression $installServiceCommand
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The term 'C:\Program Files\MongoDB\Server\5.0\bin\mongod' is not recognized as a name of a cmdlet, function,
     | script file, or executable program. Check the spelling of the name, or if a path was included, verify that the
     | path is correct and try again.
``